### PR TITLE
Pass topic to message attributes

### DIFF
--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -87,7 +87,7 @@ class PubSubJob extends Job implements JobContract
         $attempts = $this->attempts();
         $this->pubsub->republish(
             $this->job,
-            $this->queue,
+            $this->job->attribute('topic') ?: $this->queue,
             ['attempts' => (string) $attempts],
             $delay
         );

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -119,6 +119,8 @@ class PubSubQueue extends Queue implements QueueContract
             $publish['attributes'] = $this->validateMessageAttributes($options);
         }
 
+        $publish['attributes']['topic'] = $queue;
+
         $topic->publish($publish);
 
         $decoded_payload = json_decode($payload, true);
@@ -181,7 +183,7 @@ class PubSubQueue extends Queue implements QueueContract
             $this,
             $messages[0],
             $this->connectionName,
-            $this->getQueue($queue)
+            $messages[0]->attribute('topic') ?: $this->getQueue($queue)
         );
     }
 
@@ -236,6 +238,7 @@ class PubSubQueue extends Queue implements QueueContract
 
         $options = array_merge([
             'available_at' => (string) $this->availableAt($delay),
+            'topic' => $queue
         ], $this->validateMessageAttributes($options));
 
         return $topic->publish([


### PR DESCRIPTION
Fixes:
* Republish bug - default queue name is taken after the first try from PubSub config 🙅‍♂️ 
* Job logs with the default queue name