### PR TITLE
Add consumer max-time option

### DIFF
--- a/src/Commands/PubSubConsume.php
+++ b/src/Commands/PubSubConsume.php
@@ -12,7 +12,8 @@ class PubSubConsume extends Command
      */
     protected $signature = 'pubsub:consume
                             {sub-name : The name of the sub to consume}
-                            {--sleep=3 : Number of seconds to sleep when no job is available}';
+                            {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--max-time=0 : The maximum number of seconds the worker should run}';
 
     /**
      * @var string
@@ -26,10 +27,19 @@ class PubSubConsume extends Command
     {
         $this->setSubscriptionToConsume($this->getSubscriptionName());
 
-        Artisan::call('queue:work',
-            ['connection' => 'pubsub', '--sleep' => $this->getSleepOption()],
-            $this->output
-        );
+        Artisan::call('queue:work', $this->getOptions(), $this->output);
+    }
+
+    /**
+     * @return array
+     */
+    private function getOptions(): array
+    {
+        return [
+            'connection' => 'pubsub',
+            '--sleep' => $this->getSleepOption(),
+            '--max-time' => $this->getMaxTimeOption()
+        ];
     }
 
     /**
@@ -56,5 +66,13 @@ class PubSubConsume extends Command
     private function getSleepOption(): string
     {
         return $this->option('sleep');
+    }
+
+    /**
+     * @return string
+     */
+    private function getMaxTimeOption(): string
+    {
+        return $this->option('max-time');
     }
 }


### PR DESCRIPTION
`This option may be useful when combined with Supervisor so that your workers are automatically restarted after processing jobs for a given amount of time, releasing any memory they may have accumulated`